### PR TITLE
Adding module to JSON output

### DIFF
--- a/json_logging/__init__.py
+++ b/json_logging/__init__.py
@@ -236,6 +236,7 @@ class JSONLogFormatter(logging.Formatter):
                            "logger": record.name,
                            "thread": record.threadName,
                            "level": record.levelname,
+                           "module": record.module,
                            "line_no": record.lineno,
                            "msg": record.getMessage()
                            }
@@ -262,6 +263,7 @@ class JSONLogWebFormatter(logging.Formatter):
                            "logger": record.name,
                            "thread": record.threadName,
                            "level": record.levelname,
+                           "module": record.module,
                            "line_no": record.lineno,
                            "correlation_id": _request_util.get_correlation_id(),
                            "msg": record.getMessage()

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ else:
 
 setup(
     name="json-logging",
-    version='0.0.8',
+    version='0.0.9',
     packages=find_packages(exclude=['contrib', 'docs', 'tests*', 'example', 'dist', 'build']),
     license='Apache License 2.0',
     description="JSON Python Logging",


### PR DESCRIPTION
This PR adds the `module` to JSON output for easy debugging.

Related issue: https://github.com/thangbn/json-logging-python/issues/5