### PR TITLE
Add support for including exception information in JSON logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,8 +216,11 @@ e.g.:
 	"thread": "MainThread",
 	"level": "INFO",
 	"line_no": 22,
+	"filename": "/path/to/foo.py"
+	"exc_info": "Traceback (most recent call last): \n  File "<stdin>", line 1, in <module>\n ValueError: There is something wrong with your input",
 	"correlation_id": "1975a02e-e802-11e7-8971-28b2bd90b19a",
-	"extra_property": "extra_value"
+	"extra_property": "extra_value",
+	"msg": "This is a message"
 }
 ```
 - Request log: request instrumentation logging statement which recorded request information such as response time, request size, etc.
@@ -268,8 +271,9 @@ Field | Description | Format | Example
 msg | The actual message string passed to the logger.  | string | This is a log message
 level | The log "level" indicating the severity of the log message.  | string | INFO
 thread | Identifies the execution thread in which this log message has been written.  | string | http-nio-4655
-logger | The logger name that emits the log message.
- | string | requests-logger
+logger | The logger name that emits the log message. |string | requests-logger
+filename | The file name where an exception originated | string | /path/to/foo.py
+exc_info | Traceback information about an exception | string | "Traceback (most recent call last): \n  File "<stdin>", line 1, in <module>\n ValueError: There is something wrong with your input"
 
 - request logs:
 

--- a/json_logging/__init__.py
+++ b/json_logging/__init__.py
@@ -252,6 +252,7 @@ class JSONLogFormatter(logging.Formatter):
                            "logger": record.name,
                            "thread": record.threadName,
                            "level": record.levelname,
+                           "line_no": record.lineno,
                            "module": record.module,
                            "msg": record.getMessage(),
                            }
@@ -305,7 +306,7 @@ class JSONLogWebFormatter(logging.Formatter):
         if hasattr(record, 'props'):
             json_log_object.update(record.props)
 
-        if hasattr(record, 'exc_info') or hasattr(record, 'exc_text'):
+        if record.exc_info or record.exc_text:
             json_log_object.update(self.get_exc_fields(record))
 
         return JSON_SERIALIZER(json_log_object)

--- a/json_logging/__init__.py
+++ b/json_logging/__init__.py
@@ -3,6 +3,7 @@ import json
 import logging
 import uuid
 from datetime import datetime
+import traceback
 
 from json_logging import util
 from json_logging.framework_base import RequestAdapter, ResponseAdapter, AppRequestInstrumentationConfigurator, \
@@ -225,6 +226,21 @@ class JSONLogFormatter(logging.Formatter):
     Formatter for non-web application log
     """
 
+    def get_exc_fields(self, record):
+        if record.exc_info:
+            exc_info = self.format_exception(record.exc_info)
+        else:
+            exc_info = record.exc_text
+        return {
+            'exc_info': exc_info,
+            'filename': record.filename,
+        }
+
+    @classmethod
+    def format_exception(cls, exc_info):
+
+        return ''.join(traceback.format_exception(*exc_info)) if exc_info else ''
+
     def format(self, record):
         utcnow = datetime.utcnow()
         json_log_object = {"type": "log",
@@ -237,12 +253,14 @@ class JSONLogFormatter(logging.Formatter):
                            "thread": record.threadName,
                            "level": record.levelname,
                            "module": record.module,
-                           "line_no": record.lineno,
-                           "msg": record.getMessage()
+                           "msg": record.getMessage(),
                            }
 
         if hasattr(record, 'props'):
             json_log_object.update(record.props)
+
+        if record.exc_info or record.exc_text:
+            json_log_object.update(self.get_exc_fields(record))
 
         return JSON_SERIALIZER(json_log_object)
 
@@ -251,6 +269,21 @@ class JSONLogWebFormatter(logging.Formatter):
     """
     Formatter for web application log
     """
+
+    def get_exc_fields(self, record):
+        if record.exc_info:
+            exc_info = self.format_exception(record.exc_info)
+        else:
+            exc_info = record.exc_text
+        return {
+            'exc_info': exc_info,
+            'filename': record.filename,
+        }
+
+    @classmethod
+    def format_exception(cls, exc_info):
+
+        return ''.join(traceback.format_exception(*exc_info)) if exc_info else ''
 
     def format(self, record):
         utcnow = datetime.utcnow()
@@ -271,6 +304,9 @@ class JSONLogWebFormatter(logging.Formatter):
 
         if hasattr(record, 'props'):
             json_log_object.update(record.props)
+
+        if hasattr(record, 'exc_info') or hasattr(record, 'exc_text'):
+            json_log_object.update(self.get_exc_fields(record))
 
         return JSON_SERIALIZER(json_log_object)
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ else:
 
 setup(
     name="json-logging",
-    version='0.0.9',
+    version='0.0.10',
     packages=find_packages(exclude=['contrib', 'docs', 'tests*', 'example', 'dist', 'build']),
     license='Apache License 2.0',
     description="JSON Python Logging",


### PR DESCRIPTION
This will include a `filename` and `exc_info` key in the JSON log if exception information is included in the log record with `logger.exception()` or `logger.error(exc_info=True)`

fixes #9 