### PR TITLE
Fix condition for checking root logger handlers

### DIFF
--- a/json_logging/__init__.py
+++ b/json_logging/__init__.py
@@ -81,7 +81,7 @@ def config_root_logger():
     """
     global _default_formatter
 
-    if len(logging.root.handlers) > 0:
+    if not logging.root.handlers:
         _logger.error(
             "No logging handlers found for root logger. Please made sure that you call this after you called "
             "logging.basicConfig() or logging.getLogger('root')")


### PR DESCRIPTION
Seems to got broken when moving the condition upwards. Not a big issue, but it logs a wrong message, which is annoying :) I've also wondered if we should return from the method immediately, if the root logger has no handlers. At least that was more or less the behavior before moving up the conditional.